### PR TITLE
Handle relative -F includes in flist flattener

### DIFF
--- a/util/flist_flattener.py
+++ b/util/flist_flattener.py
@@ -37,9 +37,11 @@ def parseFlist(inFlist, outFlist, printIncdir, printNewline):
                 printLine(outFlist, line, printNewline)
         elif line.startswith('-F'):
             includedFilename = line.lstrip('-F').strip()
-            if not os.path.exists(includedFilename):
-                raise (RuntimeError(f'{includedFilename} not found'))
-            with open(includedFilename, 'r') as includedFlist:
+            includePath = os.path.join(os.path.dirname(inFlist.name),
+                                       includedFilename)
+            if not os.path.exists(includePath):
+                raise RuntimeError(f'{includePath} not found')
+            with open(includePath, 'r') as includedFlist:
                 parseFlist(includedFlist, outFlist, printIncdir, printNewline)
         elif line:
             printLine(outFlist, line, printNewline)

--- a/util/tests/test_flist_flattener.py
+++ b/util/tests/test_flist_flattener.py
@@ -1,0 +1,36 @@
+import io
+import unittest
+from pathlib import Path
+
+from util.flist_flattener import parseFlist
+
+
+class FlistFlattenerTest(unittest.TestCase):
+
+    def test_nested_relative_include(self):
+        with self.subTest("nested includes"):  # using subtest for clarity
+            from tempfile import TemporaryDirectory
+
+            with TemporaryDirectory() as tmpdir:
+                tmp_path = Path(tmpdir)
+                subdir = tmp_path / "dir" / "subdir"
+                subdir.mkdir(parents=True)
+
+                c_flist = subdir / "c.flist"
+                c_flist.write_text("foo.v\n")
+
+                b_flist = subdir.parent / "b.flist"
+                b_flist.write_text("-F subdir/c.flist\n")
+
+                a_flist = tmp_path / "a.flist"
+                a_flist.write_text("-F dir/b.flist\n")
+
+                out = io.StringIO()
+                with a_flist.open() as f_in:
+                    parseFlist(f_in, out, printIncdir=False, printNewline=True)
+
+                self.assertEqual(out.getvalue(), "foo.v\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- resolve `-F` includes relative to the current flist file
- raise a clear error if the included file is missing
- add unit test covering nested relative includes

## Testing
- `PYTHONPATH=. python3 -m unittest util.tests.test_flist_flattener -v`