### PR TITLE
Improve hybrid cache analysis CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ This provides better security isolation while maintaining performance for truste
 
 The fully associative mode uses a hash function seeded by the `HASH_SEED` parameter to randomize lookup table indices and reduce deterministic collisions.
 
-To compare these configurations, use the provided `compare_hybrid_cache_configs.sh` script. For detailed analysis, use the `analyze_hybrid_cache.py` script which generates visualizations and reports. Pass `-j` to that script to adjust the number of worker threads when parsing log files.
+To compare these configurations, use the provided `compare_hybrid_cache_configs.sh` script. For detailed analysis, use the `analyze_hybrid_cache.py` script which generates visualizations and reports. Pass `-j` to adjust the number of worker threads and `--verbose` to print progress while parsing logs.
 
 For more details, see the [hybrid_cache_validation.md](hybrid_cache_validation.md) document.
 

--- a/analyze_hybrid_cache.py
+++ b/analyze_hybrid_cache.py
@@ -49,7 +49,15 @@ def write_report(results: Dict[str, Dict[str, Dict[str, int | float]]], tests: l
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Analyze hybrid cache performance")
+    parser = argparse.ArgumentParser(
+        description="Analyze hybrid cache performance",
+        epilog=(
+            "Example:\n"
+            "  python3 analyze_hybrid_cache.py results_dir --config config/hybrid_cache_analysis.yml\n"
+            "  python3 analyze_hybrid_cache.py results_dir -o report -j 4 --verbose"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("comparison_dir", help="Directory containing comparison results")
     parser.add_argument("--config", help="YAML configuration file")
     parser.add_argument("--output", "-o", default="cache_analysis_report", help="Output directory")
@@ -59,6 +67,11 @@ def main() -> None:
         type=int,
         default=os.cpu_count(),
         help="Number of parallel workers (default: number of CPUs)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output during parsing",
     )
     args = parser.parse_args()
 
@@ -73,8 +86,16 @@ def main() -> None:
         cfg = load_config(args.config)
     except FileNotFoundError as e:
         parser.error(str(e))
+    except Exception as e:
+        parser.error(f"Failed to load configuration: {e}")
 
-    results = collect_stats(cfg["tests"], cfg["configs"], base, jobs=args.jobs)
+    results = collect_stats(
+        cfg["tests"],
+        cfg["configs"],
+        base,
+        jobs=args.jobs,
+        verbose=args.verbose,
+    )
     write_report(results, cfg["tests"], cfg["configs"], out_dir)
     print(f"Analysis report generated in {out_dir}")
 

--- a/docs/hybrid_cache/README.md
+++ b/docs/hybrid_cache/README.md
@@ -14,12 +14,19 @@ results, computes cache statistics and generates a markdown report with charts.
 python3 analyze_hybrid_cache.py <comparison_dir> --config config/hybrid_cache_analysis.yml -o report
 ```
 
+For more detailed output, pass `--verbose`:
+
+```bash
+python3 analyze_hybrid_cache.py <comparison_dir> -o report --verbose
+```
+
 - `<comparison_dir>` is the directory produced by the comparison script.
 - `--config` specifies a YAML file listing the workloads and cache
   configurations to analyse.
 - `-o` selects the output directory for the generated report.
 - `-j/--jobs` sets the number of parallel workers used when parsing logs
   (defaults to the number of CPUs).
+- `--verbose` prints progress information and warnings.
 
 ## Configuration File
 

--- a/docs/hybrid_cache/tutorial.md
+++ b/docs/hybrid_cache/tutorial.md
@@ -12,6 +12,7 @@ This short tutorial demonstrates how to compare cache configurations.
    ```bash
    python3 analyze_hybrid_cache.py hybrid_cache_comparison_<timestamp> \
           --config config/hybrid_cache_analysis.yml -o report -j 4
+          --verbose
    ```
    Replace `<timestamp>` with the directory printed at the end of the comparison
    script.

--- a/hybrid_cache/runner.py
+++ b/hybrid_cache/runner.py
@@ -14,10 +14,12 @@ def collect_stats(
     configs: Iterable[str],
     base_dir: str | Path,
     jobs: int | None = None,
+    verbose: bool = False,
 ) -> Dict[str, Dict[str, Dict[str, int | float]]]:
     """Collect cache statistics for *tests* and *configs* in *base_dir*.
 
     Each configuration is assumed to have its own directory under *base_dir*.
+    Set *verbose* to ``True`` to print progress information and warnings.
     """
 
     base_dir = Path(base_dir)
@@ -28,7 +30,11 @@ def collect_stats(
         cfg_dir = base_dir / cfg
         log_glob = list(cfg_dir.glob(f"simulation_artifacts/out_*/veri-testharness_sim/{test}.cv32a60x.log.*"))
         if not log_glob:
+            if verbose:
+                print(f"Warning: no log file found for {test} / {cfg}")
             raise FileNotFoundError(f"No log file for {test} / {cfg}")
+        if verbose:
+            print(f"Parsing log for {test} / {cfg}")
         log_file = sorted(log_glob)[-1]
         stats = parse_cache_stats(log_file)
         return test, cfg, stats


### PR DESCRIPTION
## Summary
- refine `collect_stats` with optional verbose output
- extend CLI options and error handling in `analyze_hybrid_cache.py`
- document verbose mode in hybrid cache README and tutorial
- mention verbose mode in top-level README

## Testing
- `python3 -m py_compile analyze_hybrid_cache.py hybrid_cache/*.py`