### PR TITLE
Update hybrid cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The fully associative mode uses a hash function seeded by the `HASH_SEED` parame
 
 To compare these configurations, use the provided `compare_hybrid_cache_configs.sh` script. For detailed analysis, use the `analyze_hybrid_cache.py` script which generates visualizations and reports. Pass `-j` to adjust the number of worker threads and `--verbose` to print progress while parsing logs.
 
-For more details, see the [hybrid_cache_validation.md](hybrid_cache_validation.md) document.
+For more details, see the [hybrid_cache_validation.md](hybrid_cache_validation.md) document and the [hybrid cache design overview](docs/hybrid_cache/design.md).
 See `docs/hybrid_cache/advanced_visualization.md` for instructions on generating timeline views and interactive charts.
 
 

--- a/docs/hybrid_cache/design.md
+++ b/docs/hybrid_cache/design.md
@@ -14,6 +14,26 @@ It complements `hybrid_cache_validation.md` with a concise design reference.
 The cache supports retaining or flushing data when changing modes. Additional
 algorithms such as round-robin or pseudo random victim selection are available.
 
+### Hashed Index Calculation
+In fully associative mode, a small lookup table accelerates tag matching. Each
+tag is hashed to select an entry in this table:
+
+```
+index = (tag ^ HASH_SEED ^ (tag >> log2(WAYS))) % WAYS
+```
+
+The `HASH_SEED` parameter randomises the distribution of tags across the table,
+reducing systematic collisions. If a hit is not found at the hashed index, the
+lookup logic falls back to a full search over all ways.
+
+### Entry Reorganisation on Mode Switch
+When the cache switches between set associative and fully associative modes with
+`REPL_POLICY_RETAIN`, valid entries are preserved. Switching to fully
+associative mode copies the tags of each active way into the lookup table using
+the hashed index calculation. Switching back rebuilds the set associative view
+by writing each cached line to its physical set. Only the minimal number of
+lines are moved; unused entries remain invalid.
+
 ## Usage
 Set the `DCacheType` parameter in the configuration package to one of the modes
 above. The analysis utilities found in this repository can be used to benchmark

--- a/hybrid_cache_validation.md
+++ b/hybrid_cache_validation.md
@@ -1,6 +1,6 @@
 # Hybrid Cache Implementation for CVA6
 
-This document describes the hybrid cache implementation that switches between set associative and fully associative organizations based on privilege level.
+This document describes the hybrid cache implementation that switches between set associative and fully associative organizations based on privilege level. A concise design summary is available in [docs/hybrid_cache/design.md](docs/hybrid_cache/design.md).
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- document the hashed index calculation in fully associative mode
- describe how entries are reorganised when switching modes
- link the design reference from validation guide and README

## Testing
- `make -C docs sphinx` *(fails: sphinx-build not found)*